### PR TITLE
Added Navigation to and From Preset Component

### DIFF
--- a/atak-civ/plugin-examples/plugintemplate/app/src/main/java/com/atakmap/android/plugintemplate/CreateTimerDropDown.java
+++ b/atak-civ/plugin-examples/plugintemplate/app/src/main/java/com/atakmap/android/plugintemplate/CreateTimerDropDown.java
@@ -103,12 +103,11 @@ public class CreateTimerDropDown extends DropDownReceiver implements OnStateList
                         PluginTemplateDropDownReceiver.presets.add(timer);
                     }
                     writePresetsToJSON(PluginTemplateDropDownReceiver.presets);
-                    if(returnPreset || preset.isChecked()) {
+                    if(preset.isChecked() && returnPreset) {
                         Intent i = new Intent();
                         i.setAction(PresetComponent.SHOW_PRESETS_PAGE);
                         i.putExtra("TIMER", timer);
                         AtakBroadcast.getInstance().sendBroadcast(i);
-
                     } else {
                         Intent i = new Intent();
                         i.setAction(PluginTemplateDropDownReceiver.SHOW_PLUGIN);
@@ -205,12 +204,14 @@ public class CreateTimerDropDown extends DropDownReceiver implements OnStateList
                 this.changeSoundText.setText(defaultSound);
                 String defaultNotification = pluginContext.getResources().getStringArray(R.array.custom_notification_settings)[0];
                 this.timer.setNotifications(new ArrayList(Arrays.asList(defaultNotification)));
+                this.preset.setEnabled(true);
                 if(intent.getStringExtra("PRESET") != null) {
-                    this.returnPreset = true;
                     this.preset.setChecked(true);
                 } else {
-                    this.returnPreset = false;
+                    this.preset.setChecked(false);
                 }
+                this.returnPreset = false;
+
             }
 
         }

--- a/atak-civ/plugin-examples/plugintemplate/app/src/main/java/com/atakmap/android/plugintemplate/CreateTimerDropDown.java
+++ b/atak-civ/plugin-examples/plugintemplate/app/src/main/java/com/atakmap/android/plugintemplate/CreateTimerDropDown.java
@@ -98,11 +98,12 @@ public class CreateTimerDropDown extends DropDownReceiver implements OnStateList
                     timer.setHours(Integer.parseInt(durationHrStr));
                     timer.setSeconds(Integer.parseInt(durationSecStr));
                     TextView title =(TextView) templateView.findViewById(R.id.title);
+                    //Only re-add timer if you are not editing it
                     if (preset.isChecked() && !(returnPreset && title.getText().toString().contains("Edit"))) {
                         PluginTemplateDropDownReceiver.presets.add(timer);
-                        writePresetsToJSON(PluginTemplateDropDownReceiver.presets);
                     }
-                    if(returnPreset) {
+                    writePresetsToJSON(PluginTemplateDropDownReceiver.presets);
+                    if(returnPreset || preset.isChecked()) {
                         Intent i = new Intent();
                         i.setAction(PresetComponent.SHOW_PRESETS_PAGE);
                         i.putExtra("TIMER", timer);
@@ -169,11 +170,6 @@ public class CreateTimerDropDown extends DropDownReceiver implements OnStateList
         if (action.equals(SHOW_CREATE)) {
             showDropDown(templateView, HALF_WIDTH, FULL_HEIGHT, FULL_WIDTH,
                     HALF_HEIGHT, true);
-            if(intent.getStringExtra("PRESET") != null) {
-                this.returnPreset = true;
-            } else {
-                this.returnPreset = false;
-            }
             if (intent.getStringExtra("SELECTED_SOUND") != null) {
                 this.changeSoundText.setText(intent.getStringExtra("SELECTED_SOUND"));
                 timer.setSound(intent.getStringExtra("SELECTED_SOUND"));
@@ -201,6 +197,12 @@ public class CreateTimerDropDown extends DropDownReceiver implements OnStateList
                 this.changeSoundText.setText(defaultSound);
                 String defaultNotification = pluginContext.getResources().getStringArray(R.array.custom_notification_settings)[0];
                 this.timer.setNotifications(new ArrayList(Arrays.asList(defaultNotification)));
+            }
+            if(intent.getStringExtra("PRESET") != null) {
+                this.returnPreset = true;
+                this.preset.setChecked(true);
+            } else {
+                this.returnPreset = false;
             }
         }
     }

--- a/atak-civ/plugin-examples/plugintemplate/app/src/main/java/com/atakmap/android/plugintemplate/CreateTimerDropDown.java
+++ b/atak-civ/plugin-examples/plugintemplate/app/src/main/java/com/atakmap/android/plugintemplate/CreateTimerDropDown.java
@@ -166,8 +166,8 @@ public class CreateTimerDropDown extends DropDownReceiver implements OnStateList
         final String action = intent.getAction();
         if (action == null)
             return;
-
         if (action.equals(SHOW_CREATE)) {
+
             showDropDown(templateView, HALF_WIDTH, FULL_HEIGHT, FULL_WIDTH,
                     HALF_HEIGHT, true);
             if (intent.getStringExtra("SELECTED_SOUND") != null) {
@@ -177,13 +177,21 @@ public class CreateTimerDropDown extends DropDownReceiver implements OnStateList
                 ArrayList<String> act = (intent.getStringArrayListExtra("SELECTED_NOTIFICATIONS"));
                 timer.setNotifications(act);
             } else if (intent.getSerializableExtra("TIMER") != null) {
+                if(intent.getStringExtra("PRESET") != null) {
+                    this.returnPreset = true;
+                    this.preset.setChecked(true);
+                    this.preset.setEnabled(false);
+
+                } else {
+                    this.returnPreset = false;
+                    this.preset.setEnabled(true);
+                }
                 Timer timer = (Timer) intent.getSerializableExtra("TIMER");
                 this.timer = timer;
                 setFields(timer);
                 TextView title =(TextView) templateView.findViewById(R.id.title);
                 title.setText("Edit Timer");
-
-            }else {
+            } else {
                 TextView title =(TextView) templateView.findViewById(R.id.title);
                 title.setText("Create Timer");
                 this.timer = new Timer();
@@ -197,13 +205,14 @@ public class CreateTimerDropDown extends DropDownReceiver implements OnStateList
                 this.changeSoundText.setText(defaultSound);
                 String defaultNotification = pluginContext.getResources().getStringArray(R.array.custom_notification_settings)[0];
                 this.timer.setNotifications(new ArrayList(Arrays.asList(defaultNotification)));
+                if(intent.getStringExtra("PRESET") != null) {
+                    this.returnPreset = true;
+                    this.preset.setChecked(true);
+                } else {
+                    this.returnPreset = false;
+                }
             }
-            if(intent.getStringExtra("PRESET") != null) {
-                this.returnPreset = true;
-                this.preset.setChecked(true);
-            } else {
-                this.returnPreset = false;
-            }
+
         }
     }
 

--- a/atak-civ/plugin-examples/plugintemplate/app/src/main/java/com/atakmap/android/plugintemplate/CreateTimerDropDown.java
+++ b/atak-civ/plugin-examples/plugintemplate/app/src/main/java/com/atakmap/android/plugintemplate/CreateTimerDropDown.java
@@ -207,13 +207,13 @@ public class CreateTimerDropDown extends DropDownReceiver implements OnStateList
                 this.preset.setEnabled(true);
                 if(intent.getStringExtra("PRESET") != null) {
                     this.preset.setChecked(true);
+                    this.returnPreset = true;
+                    this.preset.setEnabled(false);
                 } else {
                     this.preset.setChecked(false);
+                    this.returnPreset = false;
                 }
-                this.returnPreset = false;
-
             }
-
         }
     }
 

--- a/atak-civ/plugin-examples/plugintemplate/app/src/main/java/com/atakmap/android/plugintemplate/PresetComponent.java
+++ b/atak-civ/plugin-examples/plugintemplate/app/src/main/java/com/atakmap/android/plugintemplate/PresetComponent.java
@@ -70,6 +70,7 @@ public class PresetComponent extends DropDownReceiver implements OnStateListener
                 // to have the preset checkbox default to checked when the create new timer screen is called from
                 // the preset screen
                 Intent i = new Intent();
+                i.putExtra("PRESET", "Pre");
                 i.setAction(CreateTimerDropDown.SHOW_CREATE);
                 AtakBroadcast.getInstance().sendBroadcast(i);
             }

--- a/atak-civ/plugin-examples/plugintemplate/app/src/main/java/com/atakmap/android/plugintemplate/PresetComponent.java
+++ b/atak-civ/plugin-examples/plugintemplate/app/src/main/java/com/atakmap/android/plugintemplate/PresetComponent.java
@@ -64,11 +64,6 @@ public class PresetComponent extends DropDownReceiver implements OnStateListener
         add_new_preset.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                //TODO: the intent created in this function will likely need at least one addition extra so
-                // that the create/edit timer screen know to return to the preset screen and not the home screen
-                // as well as not creating a running timer but just creating a new preset. It also might be good
-                // to have the preset checkbox default to checked when the create new timer screen is called from
-                // the preset screen
                 Intent i = new Intent();
                 i.putExtra("PRESET", "Pre");
                 i.setAction(CreateTimerDropDown.SHOW_CREATE);

--- a/atak-civ/plugin-examples/plugintemplate/app/src/main/java/com/atakmap/android/plugintemplate/PresetTimerListAdapter.java
+++ b/atak-civ/plugin-examples/plugintemplate/app/src/main/java/com/atakmap/android/plugintemplate/PresetTimerListAdapter.java
@@ -173,8 +173,6 @@ public class PresetTimerListAdapter extends RecyclerView.Adapter<PresetTimerList
      * @param presetTimer the preset timer that should be edited
      */
     private void goToEditScreen(Timer presetTimer) {
-        //TODO: the intent created in this function will likely need at least one addition extra so
-        // that the create/edit timer screen know to return to the preset screen and not the home screen
         Intent i = new Intent();
         i.setAction(CreateTimerDropDown.SHOW_CREATE);
         i.putExtra("TIMER", presetTimer);

--- a/atak-civ/plugin-examples/plugintemplate/app/src/main/java/com/atakmap/android/plugintemplate/PresetTimerListAdapter.java
+++ b/atak-civ/plugin-examples/plugintemplate/app/src/main/java/com/atakmap/android/plugintemplate/PresetTimerListAdapter.java
@@ -178,6 +178,7 @@ public class PresetTimerListAdapter extends RecyclerView.Adapter<PresetTimerList
         Intent i = new Intent();
         i.setAction(CreateTimerDropDown.SHOW_CREATE);
         i.putExtra("TIMER", presetTimer);
+        i.putExtra("PRESET", "Pre");
         AtakBroadcast.getInstance().sendBroadcast(i);
     }
 }


### PR DESCRIPTION
https://github.com/FuadYoussef/TwistOnTime/issues/56
- When you select preset for a timer, it no longer adds the timer to the homescreen - instead, only adding it to the preset screen and directing you to there
- If you select create a timer from the preset screen, the preset button is pre-selected
- Editing a preset timer now works (and it does not create a new timer on each edit)
- Title at top of screen should reflect whether a timer is being edited or created
- Editing a preset timer takes you back to the presets page

One Potential Concern:
Not sure what the behavior should but if you deselect preset on a timer and then save it. I can grey out the preset button so people can't do this, or I could try to delete that timer as well