### PR TITLE
Make Create Timer Duration Fields Optional

### DIFF
--- a/atak-civ/plugin-examples/plugintemplate/app/src/main/java/com/atakmap/android/plugintemplate/CreateTimerDropDown.java
+++ b/atak-civ/plugin-examples/plugintemplate/app/src/main/java/com/atakmap/android/plugintemplate/CreateTimerDropDown.java
@@ -90,10 +90,13 @@ public class CreateTimerDropDown extends DropDownReceiver implements OnStateList
                 String durationMinStr = durationMinutes.getText().toString();
                 String durationHrStr = durationHours.getText().toString();
                 String durationSecStr = durationSeconds.getText().toString();
-                if (!durationMinStr.matches("") && !nameStr.matches("") &&
-                        !durationHrStr.matches("") && !durationSecStr.matches("")) {
+                if (!nameStr.matches("") && !(durationMinStr.matches("") &&
+                        durationHrStr.matches("") && durationSecStr.matches(""))) {
                     timer.setName(nameStr);
                     timer.setPreset(preset.isChecked());
+                    if (durationMinStr.matches("")) durationMinStr = "0";
+                    if (durationSecStr.matches("")) durationSecStr = "0";
+                    if (durationHrStr.matches("")) durationHrStr = "0";
                     timer.setMinutes(Integer.parseInt(durationMinStr));
                     timer.setHours(Integer.parseInt(durationHrStr));
                     timer.setSeconds(Integer.parseInt(durationSecStr));


### PR DESCRIPTION
- You are now only required to fill in either hours, minutes, or seconds
- You still should be able to fill in all of them or any combination of them, it's just not necessary